### PR TITLE
Flag bank patches with name changes as dirty

### DIFF
--- a/librarian/Librarian.cpp
+++ b/librarian/Librarian.cpp
@@ -502,7 +502,7 @@ namespace midikraft {
 			}, automaticCategories);
 	}
 
-	void Librarian::sendBankToSynth(SynthBank const& synthBank, bool fullBank, ProgressHandler* progressHandler, std::function<void(bool completed)> finishedHandler)
+	void Librarian::sendBankToSynth(SynthBank const& synthBank, ProgressHandler* progressHandler, std::function<void(bool completed)> finishedHandler)
 	{
 		auto synth = synthBank.synth();
 		if (!synth) {
@@ -516,7 +516,7 @@ namespace midikraft {
 			int i = 0;
 			for (auto const& patch : synthBank.patches()) {
 				ignoreUnused(patch);
-				if (fullBank || synthBank.isPositionDirty(i++)) {
+				if (synthBank.isPositionDirty(i++)) {
 					count++;
 				}
 			}
@@ -532,7 +532,7 @@ namespace midikraft {
 			i = 0;
 			for (auto const& patch : synthBank.patches()) {
 				if (progressHandler) progressHandler->setMessage(fmt::format("Sending patch {} to {}", patch.name(), synth->friendlyProgramName(patch.patchNumber())));
-				if (fullBank || synthBank.isPositionDirty(i++)) {
+				if (synthBank.isPositionDirty(i++)) {
 					auto messages = programDumpCapability->patchToProgramDumpSysex(patch.patch(), patch.patchNumber());
 					synth->sendBlockOfMessagesToSynth(location->midiOutput(), messages);
 				}

--- a/librarian/Librarian.h
+++ b/librarian/Librarian.h
@@ -45,7 +45,7 @@ namespace midikraft {
 		std::vector<PatchHolder> loadSysexPatchesFromDisk(std::shared_ptr<Synth> synth, std::string const &fullpath, std::string const &filename, std::shared_ptr<AutomaticCategory> automaticCategories);
 		std::vector<PatchHolder> loadSysexPatchesManualDump(std::shared_ptr<Synth> synth, std::vector<MidiMessage> const &messages, std::shared_ptr<AutomaticCategory> automaticCategories);
 
-		void sendBankToSynth(SynthBank const& synthBank, bool fullBank, ProgressHandler *progressHandler, std::function<void(bool completed)> finishedHandler);
+		void sendBankToSynth(SynthBank const& synthBank, ProgressHandler *progressHandler, std::function<void(bool completed)> finishedHandler);
 
 		enum ExportFormatOption {
 			PROGRAM_DUMPS = 0,

--- a/librarian/SynthBank.cpp
+++ b/librarian/SynthBank.cpp
@@ -108,20 +108,8 @@ namespace midikraft {
 
 	void SynthBank::changePatchAtPosition(MidiProgramNumber programPlace, PatchHolder patch)
 	{
-		auto currentList = patches();
-		int position = programPlace.toZeroBasedDiscardingBank();
-		if (position < static_cast<int>(currentList.size())) {
-			// Check that we are not dropping a patch onto itself
-			if (currentList[position].md5() != patch.md5()) {
-				currentList[position] = patch;
-				setPatches(currentList);
-				dirtyPositions_.insert(position);
-			}
-			fillWithPatch(patch);
-		}
-		else {
-			jassertfalse;
-		}
+		updatePatchAtPosition(programPlace, patch);
+		fillWithPatch(patch);
 	}
 
 	void SynthBank::updatePatchAtPosition(MidiProgramNumber programPlace, PatchHolder patch)
@@ -129,6 +117,9 @@ namespace midikraft {
 		auto currentList = patches();
 		int position = programPlace.toZeroBasedDiscardingBank();
 		if (position < static_cast<int>(currentList.size())) {
+			if (currentList[position].md5() != patch.md5() || currentList[position].name() != patch.name())
+				dirtyPositions_.insert(position);
+				
 			currentList[position] = patch;
 			setPatches(currentList);
 		}


### PR DESCRIPTION
Enables patches with name changes to be considered dirty and thus sent to the synth.
Refactored changePatchAtPosition and updatePatchAtPosition since they were doing similar things. 