### PR TITLE
Change imports to be a specific type of lists instead of just a common ID in the patches table.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.builds/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ MidiKraft is C++ for writing software like editors and librarians to interface s
 
 MidiKraft are a set of base libraries to provide more helper classes to the awesome [JUCE](https://github.com/WeAreROLI/JUCE) framework useful when working with real life hardware MIDI synthesizers, and also to provide implementations for the individual synthesizers to be used in other programs.
 
- This is the current list of MidiKraft libraries available on github:
+ This is the current list of MidiKraft libraries available:
 
-  * [MidiKraft-base](https://github.com/christofmuc/MidiKraft-base): Base library used by all others providing some common definitions
-  * [MidiKraft-librarian](https://github.com/christofmuc/MidiKraft-librarian): Implementation of various different handshake and communication methods to retrieve and send data between the host computer and a MIDI device
-  * [MidiKraft-database](https://github.com/christofmuc/MidiKraft-database): Code to store MIDI data in a SQlite or AWS DynamoDB database
+  * [MidiKraft-base](https://github.com/christofmuc/MidiKraft/tree/main/base): Base library used by all others providing some common definitions
+  * [MidiKraft-librarian](https://github.com/christofmuc/MidiKraft/tree/main/librarian): Implementation of various different handshake and communication methods to retrieve and send data between the host computer and a MIDI device
+  * [MidiKraft-database](https://github.com/christofmuc/MidiKraft/tree/main/database): Code to store MIDI data in a SQlite or AWS DynamoDB database
 
 ## MidiKraft Synthesizer implementations
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ MidiKraft is C++ for writing software like editors and librarians to interface s
 
 MidiKraft are a set of base libraries to provide more helper classes to the awesome [JUCE](https://github.com/WeAreROLI/JUCE) framework useful when working with real life hardware MIDI synthesizers, and also to provide implementations for the individual synthesizers to be used in other programs.
 
- This is the current list of MidiKraft libraries available:
+This is the current list of MidiKraft libraries available:
 
-  * [MidiKraft-base](https://github.com/christofmuc/MidiKraft/tree/main/base): Base library used by all others providing some common definitions
-  * [MidiKraft-librarian](https://github.com/christofmuc/MidiKraft/tree/main/librarian): Implementation of various different handshake and communication methods to retrieve and send data between the host computer and a MIDI device
-  * [MidiKraft-database](https://github.com/christofmuc/MidiKraft/tree/main/database): Code to store MIDI data in a SQlite or AWS DynamoDB database
+* [MidiKraft-base](https://github.com/christofmuc/MidiKraft/tree/main/base): Base library used by all others providing some common definitions
+* [MidiKraft-librarian](https://github.com/christofmuc/MidiKraft/tree/main/librarian): Implementation of different handshake and communication methods to retrieve and send data between the host computer and a MIDI device
+* [MidiKraft-database](https://github.com/christofmuc/MidiKraft/tree/main/database): Code to store MIDI data in a SQlite or AWS DynamoDB database
 
 ## MidiKraft Synthesizer implementations
 

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -13,6 +13,7 @@ set(Sources
 	CategoryBitfield.cpp CategoryBitfield.h
 	PatchDatabase.cpp PatchDatabase.h
 	PatchFilter.cpp PatchFilter.h
+    PatchListType.h
 )
 
 set(SQLITE_CPP_INCLUDE "${CMAKE_CURRENT_LIST_DIR}/../../third_party/SQLiteCpp/include")

--- a/database/PatchDatabase.cpp
+++ b/database/PatchDatabase.cpp
@@ -444,14 +444,13 @@ namespace midikraft {
 			return result;
 		}
 
-		bool renameImport(std::string synthName, std::string importID, std::string newName) {
+		bool renameList(std::string listID, std::string newName) {
 			try {
 				assert(false);
 				SQLite::Transaction transaction(db_);
-				SQLite::Statement update(db_, "UPDATE imports set name = :NAM where id = :IID and synth = :SYN");
+				SQLite::Statement update(db_, "UPDATE lists set name = :NAM where id = :IID");
 				update.bind(":NAM", newName);
-				update.bind(":IID", importID);
-				update.bind(":SYN", synthName);
+				update.bind(":IID", listID);
 				int rowsModified = update.exec();
 				if (rowsModified == 1) {
 					// Success
@@ -459,16 +458,16 @@ namespace midikraft {
 					return true;
 				}
 				else if (rowsModified == 0) {
-					spdlog::error("Failed to update import - not found with ID {}", importID);
+					spdlog::error("Failed to update name of list - not found with ID {}", listID);
 					return false;
 				}
 				else {
-					spdlog::error("Failed to update import, abort - more than one row found with ID {}", importID);
+					spdlog::error("Failed to update name of list, abort - more than one row found with ID {}", listID);
 					return false;
 				}
 			}
 			catch (SQLite::Exception& ex) {
-				spdlog::error("DATABASE ERROR in renameImport: SQL Exception {}", ex.what());
+				spdlog::error("DATABASE ERROR in renameList: SQL Exception {}", ex.what());
 				return false;
 			}
 		}
@@ -1981,8 +1980,8 @@ namespace midikraft {
 		PatchDataBaseImpl::makeDatabaseBackup(databaseFile, backupFileToCreate);
 	}
 
-	bool PatchDatabase::renameImport(std::string synthName, std::string importID, std::string newName) {
-		return impl->renameImport(synthName, importID, newName);
+	bool PatchDatabase::renameList(std::string listID, std::string newName) {
+		return impl->renameList(listID, newName);
 	}
 
 	std::vector<Category> PatchDatabase::getCategories() const {

--- a/database/PatchDatabase.cpp
+++ b/database/PatchDatabase.cpp
@@ -476,7 +476,8 @@ namespace midikraft {
 		}
 
 		std::vector<ImportInfo> getImportsList(Synth* activeSynth) {
-			SQLite::Statement query(db_, "SELECT lists.name, lists.id, count(patch_in_list.md5) AS patchCount FROM lists JOIN patch_in_list on lists.id == patch_in_list.id where lists.synth = :SYN AND patch_in_list.synth = :SYN AND lists.list_type = 3 GROUP BY lists.id ORDER BY lists.last_synced");
+			auto queryStr = fmt::format("SELECT lists.name, lists.id, count(patch_in_list.md5) AS patchCount FROM lists JOIN patch_in_list on lists.id == patch_in_list.id where lists.synth = :SYN AND patch_in_list.synth = :SYN AND lists.list_type = {} GROUP BY lists.id ORDER BY lists.last_synced", (int)PatchListType::IMPORT_LIST);
+			SQLite::Statement query(db_, queryStr);
 			query.bind(":SYN", activeSynth->getName());
 			std::vector<ImportInfo> result;
 			while (query.executeStep()) {

--- a/database/PatchDatabase.cpp
+++ b/database/PatchDatabase.cpp
@@ -522,9 +522,6 @@ namespace midikraft {
 				}
 				where += " ) ";
 			}
-			/*if (!filter.importID.empty()) {
-				where += " AND sourceID = :SID";
-			}*/
 			if (!filter.name.empty()) {
 				where += " AND (patches.name LIKE :NAM or patches.comment LIKE :NAM or patches.author LIKE :NAM or patches.info LIKE :NAM)";
 				if (needsCollate) {
@@ -655,9 +652,6 @@ namespace midikraft {
 			for (auto const& synth : filter.synths) {
 				query.bind(synthVariable(s++), synth.second.lock()->getName());
 			}
-			/*if (!filter.importID.empty()) {
-				query.bind(":SID", filter.importID);
-			}*/
 			if (!filter.listID.empty()) {
 				query.bind(":LID", filter.listID);
 			}

--- a/database/PatchDatabase.cpp
+++ b/database/PatchDatabase.cpp
@@ -334,6 +334,8 @@ namespace midikraft {
 					"(ROW_NUMBER() OVER(PARTITION BY sourceID ORDER BY midiBankNo, midiProgramNo) - 1) AS order_num  "
 					"FROM patches "
 					"WHERE sourceID IS NOT NULL; ");
+				// Ensure legacy NULL hidden flags become visible (0) before new filters rely on explicit values.
+				db_.exec("UPDATE patches SET hidden = 0 WHERE hidden IS NULL");
 				// Normalize import list ids so they carry the synth name and remain unique per synth.
 				db_.exec("DROP TABLE IF EXISTS tmp_import_ids");
 				db_.exec("CREATE TEMP TABLE tmp_import_ids(old_id TEXT, synth TEXT, new_id TEXT, PRIMARY KEY(old_id, synth))");

--- a/database/PatchDatabase.cpp
+++ b/database/PatchDatabase.cpp
@@ -446,7 +446,6 @@ namespace midikraft {
 
 		bool renameList(std::string listID, std::string newName) {
 			try {
-				assert(false);
 				SQLite::Transaction transaction(db_);
 				SQLite::Statement update(db_, "UPDATE lists set name = :NAM where id = :IID");
 				update.bind(":NAM", newName);

--- a/database/PatchDatabase.cpp
+++ b/database/PatchDatabase.cpp
@@ -5,6 +5,7 @@
 */
 
 #include "PatchDatabase.h"
+#include "PatchListType.h"
 
 #include "Capability.h"
 #include "Patch.h"
@@ -57,14 +58,6 @@ namespace midikraft {
 	/* 15 - adding sort order field to categories */
 	/* 16 - adding regular flag to patches */
 	/* 17 - move the imports information into the list table, and create the corresponding patch_in_list entries. Add list type for quick filtering. */
-
-	// This is stored in the list_type column
-	enum PatchListType {
-		NORMAL_LIST = 0,
-		SYNTH_BANK = 1,
-		USER_BANK = 2,
-		IMPORT_LIST = 3
-	};
 
 	class PatchDatabase::PatchDataBaseImpl {
 	public:

--- a/database/PatchDatabase.cpp
+++ b/database/PatchDatabase.cpp
@@ -1756,17 +1756,21 @@ namespace midikraft {
 				search.bind(":ID", patchList->id());
 				auto isSynthBank = std::dynamic_pointer_cast<SynthBank>(patchList);
 				if (search.executeStep()) {
-					// List already exists, just update the name (or touch the last sync timestamp in case of synth banks)
+					// List already exists, update the name, type, and timestamp as needed
 					if (!isSynthBank) {
-						SQLite::Statement update(db_, "UPDATE lists SET name = :NAM WHERE id = :ID");
+						SQLite::Statement update(db_, "UPDATE lists SET name = :NAM, list_type = :LTY WHERE id = :ID");
 						update.bind(":ID", patchList->id());
 						update.bind(":NAM", patchList->name());
+						int list_type = std::dynamic_pointer_cast<ImportList>(patchList) ? PatchListType::IMPORT_LIST : PatchListType::NORMAL_LIST;
+						update.bind(":LTY", list_type);
 						update.exec();
 					}
 					else {
-						SQLite::Statement update(db_, "UPDATE lists SET name = :NAM, last_synced = :LSY WHERE id = :ID");
+						SQLite::Statement update(db_, "UPDATE lists SET name = :NAM, last_synced = :LSY, list_type = :LTY WHERE id = :ID");
 						update.bind(":ID", patchList->id());
 						update.bind(":NAM", patchList->name());
+						int list_type = std::dynamic_pointer_cast<UserBank>(patchList) ? PatchListType::USER_BANK : PatchListType::SYNTH_BANK;
+						update.bind(":LTY", list_type);
 						if (auto activeBank = std::dynamic_pointer_cast<midikraft::ActiveSynthBank>(patchList)) {
 							update.bind(":LSY", (int64_t)activeBank->lastSynced().toMilliseconds());
 						}

--- a/database/PatchDatabase.cpp
+++ b/database/PatchDatabase.cpp
@@ -329,7 +329,7 @@ namespace midikraft {
 				// TODO - Fix editbuffer IDs, they must be unique and contain the synth name
 				// TODO - speed. which indexes do I need?
 				// Update schema and commit
-				db_.exec("UPDATE schema_version SET number = 14");
+				db_.exec("UPDATE schema_version SET number = 17");
 				transaction.commit();
 			}
 		}

--- a/database/PatchDatabase.cpp
+++ b/database/PatchDatabase.cpp
@@ -327,7 +327,9 @@ namespace midikraft {
 					"FROM patches "
 					"WHERE sourceID IS NOT NULL; ");
 				// TODO - Fix editbuffer IDs, they must be unique and contain the synth name
-				// TODO - speed. which indexes do I need?
+				db_.exec("CREATE INDEX IF NOT EXISTS idx_pil_id_order_md5_synth ON patch_in_list(id, order_num, md5, synth)");
+				db_.exec("CREATE INDEX IF NOT EXISTS idx_patches_visible  ON patches(synth, md5) WHERE hidden = 0");
+
 				// Update schema and commit
 				db_.exec("UPDATE schema_version SET number = 17");
 				transaction.commit();
@@ -535,8 +537,8 @@ namespace midikraft {
 				where += " AND type == :TYP";
 			}
 
-			std::string hiddenFalse = "(hidden is null or hidden != 1)";
-			std::string hiddenTrue = "(hidden == 1)";
+			std::string hiddenFalse = "(hidden = 0)";
+			std::string hiddenTrue = "(hidden != 0)";
 			std::string favoriteTrue = "(favorite == 1)";
 			std::string favoriteFalse = "(favorite != 1)";
 			std::string regularTrue = "(regular == 1)";

--- a/database/PatchDatabase.cpp
+++ b/database/PatchDatabase.cpp
@@ -1702,7 +1702,8 @@ namespace midikraft {
 					return nullptr;
 				}
 				auto listTypeValue = queryList.getColumn("list_type").getInt();
-				switch (listTypeValue) {
+				auto listType = static_cast<PatchListType>(listTypeValue);
+				switch (listType) {
 				case PatchListType::NORMAL_LIST:
 					list = std::make_shared<midikraft::PatchList>(listID, queryList.getColumn("name").getText());
 					break;

--- a/database/PatchDatabase.h
+++ b/database/PatchDatabase.h
@@ -84,7 +84,7 @@ namespace midikraft {
 		void makeDatabaseBackup(File backupFileToCreate);
 		static void makeDatabaseBackup(File databaseFile, File backupFileToCreate);
 
-		bool renameImport(std::string synthName, std::string importID, std::string newName);
+		bool renameList(std::string listID, std::string newName);
 
 		std::vector<Category> getCategories() const;
 		std::shared_ptr<AutomaticCategory> getCategorizer();

--- a/database/PatchDatabase.h
+++ b/database/PatchDatabase.h
@@ -20,12 +20,6 @@
 
 namespace midikraft {
 
-	struct ImportInfo {
-		std::string name; // The name of the import
-		std::string id; // The database ID, as a unique identifier
-		int countPatches; // The number of patches that currently macht this import ID
-	};
-
 	struct ListInfo {
 		std::string id; // The database ID
 		std::string name; // The given name of the list
@@ -76,7 +70,6 @@ namespace midikraft {
 		void getPatchesAsync(PatchFilter filter, std::function<void(PatchFilter const filteredBy, std::vector<PatchHolder> const &)> finished, int skip, int limit);
 
 		size_t mergePatchesIntoDatabase(std::vector<PatchHolder> &patches, std::vector<PatchHolder> &outNewPatches, ProgressHandler *progress, unsigned updateChoice);
-		std::vector<ImportInfo> getImportsList(Synth *activeSynth) const;
 		bool putPatch(PatchHolder const &patch);
 		bool putPatches(std::vector<PatchHolder> const &patches);
 
@@ -98,6 +91,7 @@ namespace midikraft {
 		std::vector<ListInfo> allSynthBanks(std::shared_ptr<Synth> synth);
 		std::vector<ListInfo> allUserBanks(std::shared_ptr<Synth> synth);
 		std::vector<ListInfo> allPatchLists();
+		std::vector<ListInfo> allImportLists(std::shared_ptr<Synth> synth);
 		bool doesListExist(std::string listId);
 		std::shared_ptr<PatchList> getPatchList(ListInfo info, std::map<std::string, std::weak_ptr<Synth>> synths);
 		void putPatchList(std::shared_ptr<PatchList> patchList);

--- a/database/PatchFilter.cpp
+++ b/database/PatchFilter.cpp
@@ -64,8 +64,7 @@ namespace midikraft {
 			return true;
 
 		// Then check simple fields
-		return a.importID != b.importID
-			|| a.name != b.name
+		return a.name != b.name
 			|| a.listID != b.listID
 			|| a.onlyFaves != b.onlyFaves
 			|| a.onlySpecifcType != b.onlySpecifcType

--- a/database/PatchFilter.h
+++ b/database/PatchFilter.h
@@ -34,7 +34,6 @@ namespace midikraft {
 
 		std::map<std::string, std::weak_ptr<Synth>> synths;
 		PatchOrdering orderBy;
-		std::string importID;
 		std::string listID;
 		std::string name;
 		bool onlyFaves;

--- a/database/PatchListType.h
+++ b/database/PatchListType.h
@@ -9,7 +9,6 @@
 namespace midikraft {
 
 	// Authoritative list type values for the lists table (see docs/imports_target_schema.md)
-	// TODO: Schema reserves 3 for ACTIVE_SYNTH_BANK/4 for imports; align when migration lands.
 	enum PatchListType {
 		NORMAL_LIST = 0,
 		SYNTH_BANK = 1,

--- a/database/PatchListType.h
+++ b/database/PatchListType.h
@@ -1,0 +1,20 @@
+/*
+   Copyright (c) 2024 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#pragma once
+
+namespace midikraft {
+
+	// Authoritative list type values for the lists table (see docs/imports_target_schema.md)
+	// TODO: Schema reserves 3 for ACTIVE_SYNTH_BANK/4 for imports; align when migration lands.
+	enum PatchListType {
+		NORMAL_LIST = 0,
+		SYNTH_BANK = 1,
+		USER_BANK = 2,
+		IMPORT_LIST = 3
+	};
+
+}

--- a/librarian/CMakeLists.txt
+++ b/librarian/CMakeLists.txt
@@ -24,6 +24,7 @@ set(Sources
 	AutomaticCategory.cpp AutomaticCategory.h
 	BinaryResources.h
 	Category.cpp Category.h
+	ImportList.cpp ImportList.h
 	JsonSchema.cpp JsonSchema.h
 	JsonSerialization.cpp JsonSerialization.h
 	Librarian.cpp Librarian.h

--- a/librarian/ImportList.cpp
+++ b/librarian/ImportList.cpp
@@ -1,0 +1,22 @@
+/*
+   Copyright (c) 2021 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#include "ImportList.h"
+
+namespace midikraft {
+
+	ImportList::ImportList(std::shared_ptr<Synth> synth, std::string const& id, std::string const& name) : 
+		PatchList(id, name)
+		, synth_(synth)
+	{
+	}
+
+	std::shared_ptr<Synth> ImportList::synth() const
+	{
+		return synth_;
+	}
+
+}

--- a/librarian/ImportList.h
+++ b/librarian/ImportList.h
@@ -1,0 +1,24 @@
+/*
+   Copyright (c) 2024 Christof Ruch. All rights reserved.
+
+   Dual licensed: Distributed under Affero GPL license by default, an MIT license is available for purchase
+*/
+
+#pragma once
+
+#include "PatchList.h"
+
+namespace midikraft {
+
+	class ImportList : public PatchList {
+	public:
+		ImportList(std::shared_ptr<Synth> synth, std::string const& id, std::string const &name);
+        virtual ~ImportList() = default;
+
+		std::shared_ptr<Synth> synth() const;
+		
+	private:
+		std::shared_ptr<Synth> synth_;
+	};
+
+}

--- a/librarian/PatchHolder.cpp
+++ b/librarian/PatchHolder.cpp
@@ -91,16 +91,6 @@ namespace midikraft {
 		return name_;
 	}
 
-	void PatchHolder::setSourceId(std::string const &source_id)
-	{
-		sourceId_ = source_id;
-	}
-
-	std::string PatchHolder::sourceId() const
-	{
-		return sourceId_;
-	}
-
 	void PatchHolder::setPatchNumber(MidiProgramNumber number)
 	{
 		patchNumber_ = number;

--- a/librarian/PatchHolder.h
+++ b/librarian/PatchHolder.h
@@ -120,8 +120,6 @@ namespace midikraft {
 		void setName(std::string const &newName);
 		std::string name() const;
 
-		void setSourceId(std::string const &source_id);
-		std::string sourceId() const;
 
 		void setPatchNumber(MidiProgramNumber number);
 		MidiProgramNumber patchNumber() const;
@@ -174,7 +172,6 @@ namespace midikraft {
 		std::shared_ptr<DataFile> patch_;
 		std::weak_ptr<Synth> synth_;
 		std::string name_;
-		std::string sourceId_;
 		Favorite isFavorite_;
 		bool isRegular_;
 		bool isHidden_;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import lists are now first-class, tied to synths and manageable by list ID; new import-list type and ImportList support.

* **Bug Fixes / Behavior**
  * Patch filtering equality simplified (import-based distinctions removed).
  * Removed ability to set or query a per-patch source identifier.

* **Documentation**
  * README updated to reflect repository/library layout.

* **Chores**
  * Database schema version bumped and migrated to support list types.
  * .gitignore now ignores .builds/ directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->